### PR TITLE
Fix AUR Git package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 There's an [AUR package](https://aur.archlinux.org/packages/c-lolcat):
 
 ```bash
-$ git clone https://aur.archlinux.org/packages/c-lolcat
+$ git clone https://aur.archlinux.org/c-lolcat.git
 $ cd c-lolcat
 $ makepkg -csi
 ```


### PR DESCRIPTION
Unlike GitHub, the package page is plain and does not have the headers necessary for a direct `git clone`.