### PR TITLE
ignore `lolcat` and `censor`, add Debian dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 lolcat.o
 censor.o
+lolcat
+censor

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ make lolcat
 
 ### Others
 
+Debian may need the `python-is-python3` package.
+
 ```bash
 $ make && sudo make install
 ```


### PR DESCRIPTION
- Ignore compiled `lolcat` and `censor`.
- Add package dependency for Debian.