### PR TITLE
Fix POSIX compliance for illumos build

### DIFF
--- a/lolcat.c
+++ b/lolcat.c
@@ -13,7 +13,7 @@
  * 0. You just DO WHAT THE FUCK YOU WANT TO.
  */
 
-#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
 
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
This change makes the code compatible with XPG6 as suggested in https://github.com/jaseg/lolcat/issues/61#issuecomment-2558233882

In this way we fix the building on illumos platforms spotted in jaseg/lolcat#61. Just tested the fix on FreeBSD/amd64 14.2: the build completed successfully. So I guess this change won't break builds on other platforms.