### PR TITLE
Fix short seed flag

### DIFF
--- a/do_release.sh
+++ b/do_release.sh
@@ -7,15 +7,15 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
-if [ -n "$(git status --porcelain|grep -v '^??')" ]; then
+if git status --porcelain | grep -q -v '^??'; then
     echo "do_release.sh must be called from a clean working directory."
     exit 2
 fi
 
 VER="$1"
 
-if echo "$VER" | grep -v '^[0-9]\+\.[0-9]\+$'; then
-    echo "do_release.sh must be called with a version number formatted like "1.23" as its first argument, with no leading \"v\"."
+if echo "$VER" | grep -q -v '^[0-9]\+\.[0-9]\+$'; then
+    echo "do_release.sh must be called with a version number formatted like \"1.23\" as its first argument, with no leading \"v\"."
     exit 1
 fi
 
@@ -25,7 +25,6 @@ sed -i "/L\"lolcat version [0-9.]\+, (c) [0-9]\+ jaseg\\\\n\"/s/version [0-9.]\+
 sed -i "s/^pkgver=v[0-9.]\+/pkgver=v$VER/" PKGBUILD
 sed -i "/^AC_INIT/s/\[[0-9.]\+\]/[$VER]/" autotools/configure.ac
 git add lolcat.c PKGBUILD autotools/configure.ac
-git commit -m 'Bump version to v$VER'
-git tag "v$VER"
+git commit -m "Bump version to v$VER"
+git tag "v$VER" -m "Bump version to v$VER"
 echo "Success."
-

--- a/lolcat.c
+++ b/lolcat.c
@@ -239,7 +239,7 @@ int main(int argc, char** argv)
             force_locale = 0;
         } else if (!strcmp(argv[i], "-r") || !strcmp(argv[i], "--random")) {
             random = 1;
-        } else if (!strcmp(argv[i], "-S") || !strcmp(argv[i], "--seed")) {
+        } else if (!strcmp(argv[i], "-s") || !strcmp(argv[i], "--seed")) {
             random = 1;
             if ((++i) < argc) {
                 seed = strtoul(argv[i], &endptr, 10);


### PR DESCRIPTION
Using `-s` flag as stated on help documentation doesn't work because of a typo. Since all short flags are lowercase I assume problem is in code and not doc.

`shellcheck` is happy so I am.

---

extra: `color_offset` flag exists, it uses underscore but all other long flags use dash. Should be changed?
